### PR TITLE
Update HCP Module to include `tier` required parameter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,6 +88,7 @@ resource "hcp_boundary_cluster" "boundary_cluster" {
   cluster_id = var.boundary_cluster_name
   username   = var.boundary_user
   password   = var.boundary_password
+  tier       = var.boundary_cluster_tier
   lifecycle {
     # Check boundary_user and boundary_password isn't the default value
     precondition {

--- a/main.tf
+++ b/main.tf
@@ -89,6 +89,7 @@ resource "hcp_boundary_cluster" "boundary_cluster" {
   username   = var.boundary_user
   password   = var.boundary_password
   tier       = var.boundary_cluster_tier
+
   lifecycle {
     # Check boundary_user and boundary_password isn't the default value
     precondition {

--- a/variables.tf
+++ b/variables.tf
@@ -225,6 +225,16 @@ variable "boundary_password" {
   default     = ""
 }
 
+variable "boundary_cluster_tier" {
+  description = "Tier HCP Boundary cluster that will be created"
+  type        = string
+  default     = ""
+  validation {
+    condition     = can(regex("Standard|Plus", var.boundary_cluster_tier))
+    error_message = "The variable must contain 'Standard' or 'Plus'"
+  }
+}
+
 variable "output_boundary_password" {
   description = "Conditional that allows for the password to be output as a sensitive value"
   type        = bool


### PR DESCRIPTION
The HCP Provider recently added the `tier` parameter that is required in versions above 0.65.0.  This PR adds a Variable, Validation check and the parameter to the `hcp_boundary_cluster` resource